### PR TITLE
fix a typo in ConfigReader

### DIFF
--- a/aslam_offline_calibration/kalibr/python/kalibr_common/ConfigReader.py
+++ b/aslam_offline_calibration/kalibr/python/kalibr_common/ConfigReader.py
@@ -65,7 +65,7 @@ class AslamCamera(object):
                                             principalPoint[0], principalPoint[1], 
                                             resolution[0], resolution[1])
                 
-                self.camera = cv.PinholeCameraGeometry(proj)
+                self.geometry = cv.PinholeCameraGeometry(proj)
                 
                 self.frameType = cv.PinholeFrame
                 self.keypointType = cv.Keypoint2


### PR DESCRIPTION
Fix a typo in ConfigReader for pinhole-none, which kalibr_calibrate_imu_camera relies on